### PR TITLE
WIP: admin approval

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -17,3 +17,13 @@ $c = $app->getContainer();
 \OC_App::registerLogIn(array('name' => $c->query('L10N')->t('Register'), 'href' => $c->query('URLGenerator')->linkToRoute('registration.register.askEmail')));
 
 \OCP\App::registerAdmin($c->getAppName(), 'admin');
+
+// Witchcraft!
+$request = \OC::$server->getRequest();
+if (isset($request->server['REQUEST_URI'])) {
+	$url = $request->server['REQUEST_URI'];
+	if (preg_match('%index.php/settings/users(/.*)?%', $url)) {
+		\OCP\Util::addScript('registration', 'settings-users-inject');
+		\OCP\Util::addStyle('registration', 'settings-users-inject');
+	}
+}

--- a/appinfo/database.xml
+++ b/appinfo/database.xml
@@ -16,9 +16,18 @@
 				<primary>true</primary>
 			</field>
 			<field>
+				<name>username</name>
+				<type>text</type>
+				<notnull>true</notnull>
+			</field>
+			<field>
 				<name>email</name>
 				<type>text</type>
 				<notnull>true</notnull>
+			</field>
+			<field>
+				<name>display_name</name>
+				<type>text</type>
 			</field>
 			<field>
 				<name>token</name>
@@ -29,6 +38,20 @@
 				<name>requested</name>
 				<type>timestamp</type>
 				<notnull>true</notnull>
+			</field>
+			<field>
+				<name>password</name>
+				<type>text</type>
+				<notnull>true</notnull>
+			</field>
+			<field>
+				<name>email_validated</name>
+				<type>boolean</type>
+				<default>false</default>
+			</field>
+			<field>
+				<name>approved</name>
+				<type>boolean</type>
 			</field>
 		</declaration>
 	</table>

--- a/css/settings-users-inject.css
+++ b/css/settings-users-inject.css
@@ -1,0 +1,9 @@
+table#reglist > tbody > tr {
+	height: 39px;
+}
+
+.reg-approve, .reg-deny {
+	padding-left: 25px;
+	background-position: 5px center;
+	padding: 3px 6px 3px 25px;
+}

--- a/css/settings-users-inject.css
+++ b/css/settings-users-inject.css
@@ -2,7 +2,7 @@ table#reglist > tbody > tr {
 	height: 39px;
 }
 
-.reg-approve, .reg-deny {
+.reg-approve, .reg-deny, .reg-delete {
 	padding-left: 25px;
 	background-position: 5px center;
 	padding: 3px 6px 3px 25px;

--- a/css/style.css
+++ b/css/style.css
@@ -1,8 +1,9 @@
-#email, #username, #password {
+input[type="email"], input[type="text"], input[type="password"] {
 	width: 223px !important;
 	padding-left: 36px !important;
 }
-#email-icon, #username-icon, #password-icon {
+
+form img.svg {
 	position: absolute;
 	left: 16px;
 	top: 22px;

--- a/db/pendingregist.php
+++ b/db/pendingregist.php
@@ -17,13 +17,13 @@ class PendingRegist {
 		$this->random = $random;
 	}
 
-	public function save($email) {
+	public function save(string $username, string $display_name, string $email, string $password) {
 		$query = $this->db->prepareQuery( 'INSERT INTO `*PREFIX*registration`'
-			.' ( `email`, `token`, `requested` ) VALUES( ?, ?, NOW() )' );
+			.' ( `username`, `display_name`, `email`, `password`, `token`, `requested` ) VALUES( ?, ?, ?, ?, ?, NOW() )' );
 		
 		$token = $this->random->generate(6, ISecureRandom::CHAR_UPPER.ISecureRandom::CHAR_DIGITS);
 		
-		$query->execute(array( $email, $token ));
+		$query->execute(array( $username, $display_name, $email, $password, $token ));
 		return $token;
 	}
 	public function find($email) {

--- a/js/settings-users-inject.js
+++ b/js/settings-users-inject.js
@@ -11,13 +11,15 @@
 
 	var PENDING_USER = '';
 	var REG_CONTENT = 
-	'<div id="reg-content" style="display none;">' +
+	'<div id="reg-content" style="display: none; overflow-y: auto;">' +
 	'	<table id="reglist" class="grid">' +
 	'		<thead>' +
 	'			<tr>' +
 	'				<th>{{label-username}}</th>' +
 	'				<th>{{label-email}}</th>' +
-	'				<th></th>' +
+	'				<th>{{label-displayname}}</th>' +
+	'				<th>{{label-emailverified}}</th>' +
+	'				<th>{{label-actions}}</th>' +
 	'			</tr>' +
 	'		</thead>' +
 	'		<tbody>' +
@@ -25,7 +27,14 @@
 	'			<tr>' +
 	'				<td>{{this.username}}</td>' +
 	'				<td>{{this.email}}</td>' +
-	'				<td><a class="reg-deny icon-close">Deny</a> <a class="reg-approve icon-checkmark">Approve</a></td>' +
+	'				<td>{{this.displayname}}</td>' +
+	'				<td>{{#if this.emailverified}}' +
+	'					<i class="reg-approve icon-checkmark"></i>'+
+	'					{{else}}'+
+	'					<i class="reg-deny icon-close"></i>'+
+	'					{{/if}}</td>' +
+	'				<td><a class="reg-deny icon-close">{{../label-deny}}</a> <a class="reg-approve icon-checkmark">{{../label-approve}}</a> '+
+	'				<a class="reg-delete icon-delete">{{../label-delete}}</a></td>' +
 	'			</tr>' +
 	'			{{/each}}' +
 	'		</tbody>' +
@@ -38,8 +47,14 @@
 		$('#app-content').after(reg_content({
 			'label-username': t('registration', 'Username'),
 			'label-email': t('registration', 'Email'),
+			'label-displayname': t('registration', 'Display Name'),
+			'label-emailverified': t('registration', 'Email Verified'),
+			'label-actions': t('registration', 'Actions'),
+			'label-approve': t('registration', 'Approve'),
+			'label-deny': t('registration', 'Deny'),
+			'label-delete': t('registration', 'Delete'),
 			'users': [
-				{'username': 'clubmate', 'email': 'clib@mate.me'},
+				{'username': 'clubmate', 'email': 'clib@mate.me', 'displayname': 'John Doe', 'email_validated': false},
 			],
 		}));
 		// TODO only append when count>0

--- a/js/settings-users-inject.js
+++ b/js/settings-users-inject.js
@@ -1,0 +1,56 @@
+(function() {
+	var GROUPLIST_TEMPLATE = 
+	'<li data-gid="registration" data-usercount="{{count}}" class="">' +
+	'<a id="pending-reg" href="#" class="">' +
+	'<span class="groupname" style="font-weight: bold;">{{label}}</span>' +
+	'</a>' +
+	'<span class="utils">' +
+	'<span class="usercount">{{count}}</span>' +
+	'</span>' +
+	'</li>';
+
+	var PENDING_USER = '';
+	var REG_CONTENT = 
+	'<div id="reg-content" style="display none;">' +
+	'	<table id="reglist" class="grid">' +
+	'		<thead>' +
+	'			<tr>' +
+	'				<th>{{label-username}}</th>' +
+	'				<th>{{label-email}}</th>' +
+	'				<th></th>' +
+	'			</tr>' +
+	'		</thead>' +
+	'		<tbody>' +
+	'			{{#each users}}' +
+	'			<tr>' +
+	'				<td>{{this.username}}</td>' +
+	'				<td>{{this.email}}</td>' +
+	'				<td><a class="reg-deny icon-close">Deny</a> <a class="reg-approve icon-checkmark">Approve</a></td>' +
+	'			</tr>' +
+	'			{{/each}}' +
+	'		</tbody>' +
+	'	</table>' +
+	'</div>';
+
+	$(document).ready(function() {
+		var grouplist_template = Handlebars.compile(GROUPLIST_TEMPLATE);
+		var reg_content = Handlebars.compile(REG_CONTENT);
+		$('#app-content').after(reg_content({
+			'label-username': t('registration', 'Username'),
+			'label-email': t('registration', 'Email'),
+			'users': [
+				{'username': 'clubmate', 'email': 'clib@mate.me'},
+			],
+		}));
+		// TODO only append when count>0
+		$('#newgroup-init').after(grouplist_template({'count': '?', 'label': t('registration', 'Pending registration request')}));
+		$('#pending-reg').click(function() {
+			$('#app-content').hide();
+			$('#reg-content').show();
+		});
+		$('#usergrouplist').on('click', '.isgroup', function () {
+			$('#app-content').show();
+			$('#reg-content').hide();
+		});
+	});
+})();

--- a/templates/form.php
+++ b/templates/form.php
@@ -1,6 +1,7 @@
 <?php
 \OCP\Util::addStyle('registration', 'style');
-?><form action="<?php print_unescaped(\OC::$server->getURLGenerator()->linkToRoute('registration.register.createAccount', array('token'=>$_['token']))) ?>" method="post">
+?>
+<form action="<?php print_unescaped(\OC::$server->getURLGenerator()->linkToRoute('registration.register.validateEmail')) ?>" method="post">
 	<input type="hidden" name="requesttoken" value="<?php p($_['requesttoken']) ?>" />
 	<fieldset>
 		<?php if ( $_['errormsgs'] ) {?>
@@ -9,13 +10,9 @@
 				echo "<li>$errormsg</li>";
 			} ?>
 		</ul>
-		<?php } else { ?>
-		<ul class="msg">
-			<li><?php print_unescaped($l->t('Welcome, you can create your account below.')); ?></li>
-		</ul>
 		<?php } ?>
 		<p class="grouptop">
-		<input type="email" name="email" id="email" value="<?php echo $_['email']; ?>" disabled />
+		<input type="email" name="email" id="email" value="<?php echo $_['email']; ?>" placeholder="<?php print_unescaped($l->t('Email')); ?>" />
 		<label for="email" class="infield"><?php echo $_['email']; ?></label>
 		<img id="email-icon" class="svg" src="<?php print_unescaped(image_path('', 'actions/mail.svg')); ?>" alt=""/>
 		</p>
@@ -26,6 +23,12 @@
 		<img id="username-icon" class="svg" src="<?php print_unescaped(image_path('', 'actions/user.svg')); ?>" alt=""/>
 		</p>
 
+		<p class="groupmiddle">
+		<input type="text" name="display_name" id="display_name" value="<?php echo $_['entered_data']['display_name']; ?>" placeholder="<?php print_unescaped($l->t('Display Name')); ?>" />
+		<label for="display_name" class="infield"><?php print_unescaped($l->t('Display Name')); ?></label>
+		<img id="rename-icon" class="svg" src="<?php print_unescaped(image_path('', 'actions/rename.svg')); ?>" alt=""/>
+		</p>
+
 		<p class="groupbottom">
 		<input type="password" name="password" id="password" placeholder="<?php print_unescaped($l->t('Password')); ?>"/>
 		<label for="password" class="infield"><?php print_unescaped($l->t( 'Password' )); ?></label>
@@ -33,6 +36,6 @@
 		<input id="show" name="show" type="checkbox">
 		<label style="display: inline;" for="show"></label>
 		</p>
-		<input type="submit" id="submit" value="<?php print_unescaped($l->t('Create account')); ?>" />
+		<input type="submit" id="submit" value="<?php print_unescaped($l->t('Sign up')); ?>" />
 	</fieldset>
 </form>


### PR DESCRIPTION
Modify table to hold extra data for email validated but not approved users, new fields: 
- `username`
- `display_name`
- `password`: should be hashed using `\OC::$server->getHasher()->hash($password), $uid)` as in `OC_User_Database::setPassword()` of `lib/private/user/database.php`
- `email_validated`: boolean, default false
- `approved`: boolean, default NULL=undecided

`db/pendingregist.php`:
- [ ] `db/pendingregist.php`: `save( username, email, display_name, hashed_password )`
- [ ] `db/pendingregist.php`: `list()`
- [ ] `deny()` -> if email validated then delete row (should be done elsewhere)
- [ ] `approve()` -> if email validated then create user (should be done elsewhere)

Register form checks:
- [ ] username already exists or pending validation or pending approval
- [ ] email already exists or pending approval, if pending validation, send a new validation email

JSON endpoint for admin approval interface:
- [ ] list
- [ ] approve: createUser, set random password, immediately followed by an <code>OC_DB::prepare('UPDATE `*PREFIX*users` SET `password` = ? WHERE `uid` = ?');</code> , send email to notify the user
- [ ] deny: delete the pending registration, send email to notify the user.
- [ ] delete: delete without notification
