### PR TITLE
Support redirecting to custom URL after registration.

### DIFF
--- a/appinfo/database.xml
+++ b/appinfo/database.xml
@@ -51,6 +51,10 @@
 				<type>timestamp</type>
 				<notnull>true</notnull>
 			</field>
+			<field>
+				<name>redirect_url</name>
+				<type>text</type>
+			</field>
 		</declaration>
 	</table>
 </database>

--- a/controller/apicontroller.php
+++ b/controller/apicontroller.php
@@ -140,10 +140,11 @@ class ApiController extends OCSController {
 	 * @param string $displayname
 	 * @param string $email
 	 * @param string $password
+	 * @param string $redirect_url
 	 * @throws \Exception
 	 * @return DataResponse
 	 */
-	public function register($username, $displayname, $email, $password) {
+	public function register($username, $displayname, $email, $password, $redirect_url='') {
 		$data = [];
 		try {
 			$secret = null;
@@ -152,9 +153,13 @@ class ApiController extends OCSController {
 				$this->registrationService->validateDisplayname($displayname);
 				$this->registrationService->validateUsername($username);
 				$registration = $this->registrationService->createRegistration($email, $username, $password, $displayname);
+				if (!empty($redirect_url)) {
+					$this->registrationService->updateRedirectUrl($registration, $redirect_url);
+				}
 				$this->mailService->sendTokenByMail($registration);
 				$secret = $registration->getClientSecret();
 			} else {
+				$this->registrationService->updateRedirectUrl($registration, $redirect_url);
 				$this->registrationService->generateNewToken($registration);
 				$this->mailService->sendTokenByMail($registration);
 				return new DataResponse(

--- a/db/registration.php
+++ b/db/registration.php
@@ -36,6 +36,7 @@ class Registration extends Entity {
 	protected $requested;
 	protected $emailConfirmed;
 	protected $clientSecret;
+	protected $redirectUrl;
 
 	public function __construct() {
 		$this->addType('emailConfirmed', 'boolean');

--- a/service/registrationservice.php
+++ b/service/registrationservice.php
@@ -121,6 +121,20 @@ class RegistrationService {
 		$this->registrationMapper->generateNewToken($registration);
 		$this->registrationMapper->update($registration);
 	}
+
+	/**
+	 * @param Registration $registration
+	 * @param string $redirect_url
+	 */
+	public function updateRedirectUrl(Registration &$registration, $redirect_url) {
+		if ($redirect_url === $registration->getRedirectUrl()) {
+			return;
+		}
+
+		$registration->setRedirectUrl($redirect_url);
+		$this->registrationMapper->update($registration);
+	}
+
 	/**
 	 * Create registration request, used by both the API and form
 	 * @param string $email


### PR DESCRIPTION
The use case is to trigger sending the registration confirmation through an API and have the user enter his details after clicking on the link in the mail. After the details have been entered and the account is created, it allows to redirect to a custom URL instead of the default Nextcloud page.