### PR TITLE
Using email as username

### DIFF
--- a/lib/Controller/RegisterController.php
+++ b/lib/Controller/RegisterController.php
@@ -21,6 +21,7 @@ use \OCP\AppFramework\Http\TemplateResponse;
 use \OCP\AppFramework\Http\RedirectResponse;
 use \OCP\AppFramework\Controller;
 use OCP\IURLGenerator;
+use \OCP\IConfig;
 use \OCP\IL10N;
 
 class RegisterController extends Controller {
@@ -29,6 +30,8 @@ class RegisterController extends Controller {
 	private $l10n;
 	/** @var IURLGenerator */
 	private $urlgenerator;
+	/** @var IConfig */
+	private $config;
 	/** @var RegistrationService */
 	private $registrationService;
 	/** @var MailService */
@@ -40,12 +43,14 @@ class RegisterController extends Controller {
 		IRequest $request,
 		IL10N $l10n,
 		IURLGenerator $urlgenerator,
+		IConfig $config,
 		RegistrationService $registrationService,
 		MailService $mailService
 	) {
 		parent::__construct($appName, $request);
 		$this->l10n = $l10n;
 		$this->urlgenerator = $urlgenerator;
+		$this->config = $config;
 		$this->registrationService = $registrationService;
 		$this->mailService = $mailService;
 	}
@@ -140,9 +145,13 @@ class RegisterController extends Controller {
 	 * @return RedirectResponse|TemplateResponse
 	 */
 	public function createAccount($token) {
-		$username = $this->request->getParam('username');
-		$password = $this->request->getParam('password');
 		$registration = $this->registrationService->getRegistrationForToken($token);
+		if ($this->config->getAppValue('registration', 'email_is_login', '0') === '1') {
+			$username = $registration->email;
+		} else {
+			$username = $this->request->getParam('username');
+		}
+		$password = $this->request->getParam('password');
 
 		try {
 			$user = $this->registrationService->createAccount($registration, $username, $password);

--- a/lib/Db/Registration.php
+++ b/lib/Db/Registration.php
@@ -47,7 +47,7 @@ use OCP\AppFramework\Db\Entity;
  */
 class Registration extends Entity {
 	public $id;
-	protected $email;
+	public $email;
 	protected $username;
 	protected $displayname;
 	protected $password;

--- a/templates/form.php
+++ b/templates/form.php
@@ -23,6 +23,7 @@ script('registration', 'form');
 			<img id="email-icon" class="svg" src="<?php print_unescaped(image_path('', 'actions/mail.svg')); ?>" alt=""/>
 		</p>
 
+		<?php if ( \OC::$server->getConfig()->getAppValue('registration', 'email_is_login', '0') !== '1' ) { ?>
 		<p class="groupmiddle">
 			<input type="text" name="username" id="username" value="<?php if (!empty($_['entered_data']['user'])) {
 	p($_['entered_data']['user']);
@@ -30,6 +31,7 @@ script('registration', 'form');
 			<label for="username" class="infield"><?php p($l->t('Username')); ?></label>
 			<img id="username-icon" class="svg" src="<?php print_unescaped(image_path('', 'actions/user.svg')); ?>" alt=""/>
 		</p>
+        <?php } ?>
 
 		<p class="groupbottom">
 			<input type="password" name="password" id="password" placeholder="<?php p($l->t('Password')); ?>"/>


### PR DESCRIPTION
Ignore username input and use the mail address as login when creating the new account:

`./occ config:app:set --value '1' registration email_is_login`
