### PR TITLE
Forward error messages of the password policy directly

### DIFF
--- a/templates/form/user.php
+++ b/templates/form/user.php
@@ -6,11 +6,9 @@ script('registration', 'form');
 ?><form action="" method="post">
 	<input type="hidden" name="requesttoken" value="<?php p($_['requesttoken']) ?>" />
 	<fieldset>
-		<?php if (!empty($_['errormsgs'])) {?>
+		<?php if (!empty($_['message'])) {?>
 		<ul class="error">
-			<?php foreach ($_['errormsgs'] as $errormsg) { ?>
-			<li><?php p($errormsg); ?></li>
-			<?php } ?>
+			<li><?php p($_['message']); ?></li>
 		</ul>
 		<?php } else { ?>
 		<ul class="msg">


### PR DESCRIPTION
Fix #42 

1. Start registration process
2. Use a common/too short password etc.

Before | After
---|---
Page just reloads the form | Dedicated error is shown
![Bildschirmfoto von 2020-11-17 20-21-31](https://user-images.githubusercontent.com/213943/99437264-860bc300-2912-11eb-8787-90bad5c26e0a.png) | ![Bildschirmfoto von 2020-11-17 20-16-55](https://user-images.githubusercontent.com/213943/99437194-6c6a7b80-2912-11eb-864c-1175ebb25362.png)
