### PR TITLE
Catch exception when email is not configured

### DIFF
--- a/lib/Controller/RegisterController.php
+++ b/lib/Controller/RegisterController.php
@@ -143,6 +143,8 @@ class RegisterController extends Controller {
 			$this->mailService->sendTokenByMail($registration);
 		} catch (RegistrationException $e) {
 			return $this->showEmailForm($email, $e->getMessage());
+		} catch (\Exception $e) {
+			return $this->showEmailForm($email, $this->l10n->t('A problem occurred sending email, please contact your administrator.'));
 		}
 
 		return new RedirectResponse(
@@ -222,7 +224,7 @@ class RegisterController extends Controller {
 		} catch (RegistrationException $e) {
 			return $this->validateSecretAndTokenErrorPage();
 		}
-		
+
 		$additional_hint = $this->config->getAppValue('registration', 'additional_hint');
 
 		return new TemplateResponse('registration', 'form/user', [


### PR DESCRIPTION
Fix #267 

Before | After
---|---
![https://user-images.githubusercontent.com/13448432/105643747-f244fe80-5e4e-11eb-9659-0425c5ed54d0.png](https://user-images.githubusercontent.com/13448432/105643747-f244fe80-5e4e-11eb-9659-0425c5ed54d0.png) | ![Bildschirmfoto von 2021-02-22 19-48-03](https://user-images.githubusercontent.com/213943/108755280-5a1e6000-7547-11eb-8031-54c140ef4df1.png)
