### PR TITLE
Add the user email address in the admin notification email

### DIFF
--- a/lib/Service/MailService.php
+++ b/lib/Service/MailService.php
@@ -147,7 +147,7 @@ class MailService {
 		}
 	}
 
-	public function notifyAdmins(string $userId, bool $userIsEnabled, string $userGroupId): void {
+	public function notifyAdmins(string $userId, string $userEMailAddress, bool $userIsEnabled, string $userGroupId): void {
 		// Notify admin
 		$adminUsers = $this->groupManager->get('admin')->getUsers();
 
@@ -172,7 +172,7 @@ class MailService {
 		}
 
 		try {
-			$this->sendNewUserNotifyEmail($toArr, $userId, $userIsEnabled);
+			$this->sendNewUserNotifyEmail($toArr, $userId, $userEMailAddress, $userIsEnabled);
 		} catch (\Exception $e) {
 			$this->logger->error('Sending admin notification email failed: '. $e->getMessage());
 		}
@@ -186,7 +186,7 @@ class MailService {
 	 * @param bool $userIsEnabled the new user account is enabled
 	 * @throws \Exception
 	 */
-	private function sendNewUserNotifyEmail(array $to, string $username, bool $userIsEnabled): void {
+	private function sendNewUserNotifyEmail(array $to, string $username, string $userEMailAddress, bool $userIsEnabled): void {
 		$link = $this->urlGenerator->linkToRouteAbsolute('settings.Users.usersListByGroup', [
 			'group' => 'disabled',
 		]);
@@ -204,15 +204,17 @@ class MailService {
 
 		if ($userIsEnabled) {
 			$template->addBodyText(
-				$this->l10n->t('"%1$s" registered a new account on %2$s.', [
+				$this->l10n->t('"%1$s" (%2$s) registered a new account on %3$s.', [
 					$username,
+					$userEMailAddress,
 					$this->defaults->getName(),
 				])
 			);
 		} else {
 			$template->addBodyText(
-				$this->l10n->t('"%1$s" registered a new account on %2$s and needs to be enabled.', [
+				$this->l10n->t('"%1$s" (%2$s) registered a new account on %3$s and needs to be enabled.', [
 					$username,
+					$userEMailAddress,
 					$this->defaults->getName(),
 				])
 			);

--- a/lib/Service/RegistrationService.php
+++ b/lib/Service/RegistrationService.php
@@ -427,7 +427,7 @@ class RegistrationService {
 			$user->setEnabled(false);
 		}
 
-		$this->mailService->notifyAdmins($userId, $user->isEnabled(), $groupId);
+		$this->mailService->notifyAdmins($userId, $user->getEMailAddress(), $user->isEnabled(), $groupId);
 		return $user;
 	}
 


### PR DESCRIPTION
Solution to [issue #211](https://github.com/nextcloud/registration/issues/211#issue-642264575)
Change in email notification to administrator:

- before:
> "new_user" registered a new account on my_nextcloud
> or
> "new_user" registered a new account on my_nextcloud and needs to be enabled

- with this patch:
> "new_user" (user_email) registered a new account on my_nextcloud
> or
> "new_user" (user_email) registered a new account on my_nextcloud and needs to be enabled

Translations adapted to handle this new information.
Note:
- ES: translations of both messages transformed so that the common part is the same
- KO: uncertainty about the right place to put email address (seems to be OK according to Google translate)
- RU: persistent inconsistency between both messages (common part is not identical, but no idea about which one is better)