### PR TITLE
Added ability to hide registration link on login page.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## Changes by Ze'ev Schurmann
+### Added
+- Added ability to hide registration link on login page
+  [#621](https://github.com/nextcloud/registration/issues/621)
+
 ## 2.4.0 - 2024-03-13
 
 ### Added

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -59,6 +59,8 @@ class SettingsController extends Controller {
 		string $email_verification_hint,
 		string $username_policy_regex,
 		?bool $admin_approval_required,
+		// Define login_button_hide as boolean (thisiszeev)
+		?bool $login_button_hide,
 		?bool $email_is_optional,
 		?bool $email_is_login,
 		?bool $show_fullname,
@@ -104,6 +106,8 @@ class SettingsController extends Controller {
 		}
 
 		$this->config->setAppValue($this->appName, 'admin_approval_required', $admin_approval_required ? 'yes' : 'no');
+		// Define values for login_button_hide. (thisiszeev)
+		$this->config->setAppValue($this->appName, 'login_button_hide', $login_button_hide ? 'yes' : 'no');
 		$this->config->setAppValue($this->appName, 'email_is_optional', $email_is_optional ? 'yes' : 'no');
 		$this->config->setAppValue($this->appName, 'email_is_login', !$email_is_optional && $email_is_login ? 'yes' : 'no');
 		$this->config->setAppValue($this->appName, 'show_fullname', $show_fullname ? 'yes' : 'no');

--- a/lib/RegistrationLoginOption.php
+++ b/lib/RegistrationLoginOption.php
@@ -26,9 +26,9 @@ declare(strict_types=1);
 namespace OCA\Registration;
 
 use OCP\Authentication\IAlternativeLogin;
+use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IURLGenerator;
-use OCP\IConfig;
 
 class RegistrationLoginOption implements IAlternativeLogin {
 

--- a/lib/RegistrationLoginOption.php
+++ b/lib/RegistrationLoginOption.php
@@ -28,22 +28,33 @@ namespace OCA\Registration;
 use OCP\Authentication\IAlternativeLogin;
 use OCP\IL10N;
 use OCP\IURLGenerator;
+use OCP\IConfig;
 
 class RegistrationLoginOption implements IAlternativeLogin {
 
-	public function __construct(protected IURLGenerator $url, protected IL10N $l, protected \OC_Defaults $theming) {
+	public function __construct(protected IConfig $config, protected IURLGenerator $url, protected IL10N $l, protected \OC_Defaults $theming) {
+		$this->config = $config;
 	}
 
 	public function getLabel(): string {
-		return $this->l->t('Register');
+		// Decide if login page will display registration link (thisiszeev)
+		if ($this->config->getAppValue('registration', 'login_button_hide', 'no') === 'no') {
+			return $this->l->t('Register');
+		}
 	}
 
 	public function getLink(): string {
-		return $this->url->linkToRoute('registration.register.showEmailForm');
+		// Decide if login page will display registration link (thisiszeev)
+		if ($this->config->getAppValue('registration', 'login_button_hide', 'no') === 'no') {
+			return $this->url->linkToRoute('registration.register.showEmailForm');
+		}
 	}
 
 	public function getClass(): string {
-		return 'register-button';
+		// Decide if login page will display registration link (thisiszeev)
+		if ($this->config->getAppValue('registration', 'login_button_hide', 'no') === 'no') {
+			return 'register-button';
+		}
 	}
 
 	public function load(): void {

--- a/lib/Settings/RegistrationSettings.php
+++ b/lib/Settings/RegistrationSettings.php
@@ -54,6 +54,12 @@ class RegistrationSettings implements ISettings {
 			$this->config->getAppValue($this->appName, 'admin_approval_required', 'no') === 'yes'
 		);
 
+		// Define values for Admin Page (thisiszeev)
+		$this->initialState->provideInitialState(
+			'login_button_hide',
+			$this->config->getAppValue($this->appName, 'login_button_hide', 'no') === 'yes'
+		);
+
 		$this->initialState->provideInitialState(
 			'allowed_domains',
 			$this->config->getAppValue($this->appName, 'allowed_domains')

--- a/src/AdminSettings.vue
+++ b/src/AdminSettings.vue
@@ -31,6 +31,16 @@
 
 			<p><em>{{ t('registration', 'Enabling "administrator approval" will prevent registrations from mobile and desktop clients to complete as the credentials cannot be verified by the client until the user was enabled.') }}</em></p>
 
+<!-- Draw elements on Admin Page for loginButtonHide (thisiszeev) -->
+		<NcCheckboxRadioSwitch :checked.sync="loginButtonHide"
+				type="switch"
+				:disabled="loading"
+				@update:checked="saveData">
+				{{ t('registration', 'Hide registration button on login page') }}
+			</NcCheckboxRadioSwitch>
+
+			<p><em>{{ t('registration', 'Enabling, "hide registration button" will ensure the registration button is not displayed on the login page. Instead new users will have to be provided with the registration link, eg. https://nextcloud.domain.tld/index.php/apps/registration/, in order to register.') }}</em></p>
+
 			<div>
 				<div class="margin-top">
 					<label for="registered_user_group">
@@ -203,6 +213,8 @@ export default {
 			saveNotification: null,
 
 			adminApproval: false,
+			// Default value for loginButtonHide (thisiszeev)
+			loginButtonHide: false,
 			registeredUserGroup: '',
 			allowedDomains: '',
 			domainsIsBlocklist: false,
@@ -239,6 +251,8 @@ export default {
 
 	mounted() {
 		this.adminApproval = loadState('registration', 'admin_approval_required')
+		// (thisiszeev)
+		this.loginButtonHide = loadState('registration', 'login_button_hide')
 		this.registeredUserGroup = loadState('registration', 'registered_user_group')
 		this.allowedDomains = loadState('registration', 'allowed_domains')
 		this.domainsIsBlocklist = loadState('registration', 'domains_is_blocklist')
@@ -270,6 +284,8 @@ export default {
 			try {
 				const response = await axios.post(generateUrl('/apps/registration/settings'), {
 					admin_approval_required: this.adminApproval,
+					// (thisiszeev)
+					login_button_hide: this.loginButtonHide,
 					registered_user_group: this.registeredUserGroup?.id,
 					allowed_domains: this.allowedDomains,
 					domains_is_blocklist: this.domainsIsBlocklist,

--- a/src/AdminSettings.vue
+++ b/src/AdminSettings.vue
@@ -31,8 +31,7 @@
 
 			<p><em>{{ t('registration', 'Enabling "administrator approval" will prevent registrations from mobile and desktop clients to complete as the credentials cannot be verified by the client until the user was enabled.') }}</em></p>
 
-<!-- Draw elements on Admin Page for loginButtonHide (thisiszeev) -->
-		<NcCheckboxRadioSwitch :checked.sync="loginButtonHide"
+			<NcCheckboxRadioSwitch :checked.sync="loginButtonHide"
 				type="switch"
 				:disabled="loading"
 				@update:checked="saveData">


### PR DESCRIPTION
As per [Issue 621](https://github.com/nextcloud/registration/issues/621). I have added support for this feature. 

The ability to hide the registration link on the login page.

I did also add a comment above all my additions/changes and in each comment it has (thisiszeev). Of course the comments are to be removed, but it was mainly for me to quickly find my work when checking and debugging.

I did not do a unit test, as I do not know how. But I did build and run on a test Nextcloud instance and tested several permutations as well as cross reference to the entries in the MySQL database to ensure things were correct.