### PR TITLE
Added ability to hide registration link on login page. Issue #621

### DIFF
--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -59,6 +59,7 @@ class SettingsController extends Controller {
 		string $email_verification_hint,
 		string $username_policy_regex,
 		?bool $admin_approval_required,
+		?bool $login_button_hide,
 		?bool $email_is_optional,
 		?bool $email_is_login,
 		?bool $show_fullname,
@@ -104,6 +105,7 @@ class SettingsController extends Controller {
 		}
 
 		$this->config->setAppValue($this->appName, 'admin_approval_required', $admin_approval_required ? 'yes' : 'no');
+		$this->config->setAppValue($this->appName, 'login_button_hide', $login_button_hide ? 'yes' : 'no');
 		$this->config->setAppValue($this->appName, 'email_is_optional', $email_is_optional ? 'yes' : 'no');
 		$this->config->setAppValue($this->appName, 'email_is_login', !$email_is_optional && $email_is_login ? 'yes' : 'no');
 		$this->config->setAppValue($this->appName, 'show_fullname', $show_fullname ? 'yes' : 'no');

--- a/lib/RegistrationLoginOption.php
+++ b/lib/RegistrationLoginOption.php
@@ -26,24 +26,32 @@ declare(strict_types=1);
 namespace OCA\Registration;
 
 use OCP\Authentication\IAlternativeLogin;
+use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 
 class RegistrationLoginOption implements IAlternativeLogin {
 
-	public function __construct(protected IURLGenerator $url, protected IL10N $l, protected \OC_Defaults $theming) {
+	public function __construct(protected IConfig $config, protected IURLGenerator $url, protected IL10N $l, protected \OC_Defaults $theming) {
+		$this->config = $config;
 	}
 
 	public function getLabel(): string {
-		return $this->l->t('Register');
+		if ($this->config->getAppValue('registration', 'login_button_hide', 'no') === 'no') {
+			return $this->l->t('Register');
+		}
 	}
 
 	public function getLink(): string {
-		return $this->url->linkToRoute('registration.register.showEmailForm');
+		if ($this->config->getAppValue('registration', 'login_button_hide', 'no') === 'no') {
+			return $this->url->linkToRoute('registration.register.showEmailForm');
+		}
 	}
 
 	public function getClass(): string {
-		return 'register-button';
+		if ($this->config->getAppValue('registration', 'login_button_hide', 'no') === 'no') {
+			return 'register-button';
+		}
 	}
 
 	public function load(): void {

--- a/lib/Settings/RegistrationSettings.php
+++ b/lib/Settings/RegistrationSettings.php
@@ -55,6 +55,11 @@ class RegistrationSettings implements ISettings {
 		);
 
 		$this->initialState->provideInitialState(
+			'login_button_hide',
+			$this->config->getAppValue($this->appName, 'login_button_hide', 'no') === 'yes'
+		);
+
+		$this->initialState->provideInitialState(
 			'allowed_domains',
 			$this->config->getAppValue($this->appName, 'allowed_domains')
 		);

--- a/src/AdminSettings.vue
+++ b/src/AdminSettings.vue
@@ -31,6 +31,15 @@
 
 			<p><em>{{ t('registration', 'Enabling "administrator approval" will prevent registrations from mobile and desktop clients to complete as the credentials cannot be verified by the client until the user was enabled.') }}</em></p>
 
+			<NcCheckboxRadioSwitch :checked.sync="loginButtonHide"
+				type="switch"
+				:disabled="loading"
+				@update:checked="saveData">
+				{{ t('registration', 'Hide registration button on login page') }}
+			</NcCheckboxRadioSwitch>
+
+			<p><em>{{ t('registration', 'Enabling, "hide registration button" will ensure the registration button is not displayed on the login page. Instead new users will have to be provided with the registration link, eg. https://nextcloud.domain.tld/index.php/apps/registration/, in order to register.') }}</em></p>
+
 			<div>
 				<div class="margin-top">
 					<label for="registered_user_group">
@@ -203,6 +212,7 @@ export default {
 			saveNotification: null,
 
 			adminApproval: false,
+			loginButtonHide: false,
 			registeredUserGroup: '',
 			allowedDomains: '',
 			domainsIsBlocklist: false,
@@ -239,6 +249,7 @@ export default {
 
 	mounted() {
 		this.adminApproval = loadState('registration', 'admin_approval_required')
+		this.loginButtonHide = loadState('registration', 'login_button_hide')
 		this.registeredUserGroup = loadState('registration', 'registered_user_group')
 		this.allowedDomains = loadState('registration', 'allowed_domains')
 		this.domainsIsBlocklist = loadState('registration', 'domains_is_blocklist')
@@ -270,6 +281,7 @@ export default {
 			try {
 				const response = await axios.post(generateUrl('/apps/registration/settings'), {
 					admin_approval_required: this.adminApproval,
+					login_button_hide: this.loginButtonHide,
 					registered_user_group: this.registeredUserGroup?.id,
 					allowed_domains: this.allowedDomains,
 					domains_is_blocklist: this.domainsIsBlocklist,


### PR DESCRIPTION
Added the ability to hide the registration link on login. New users have to be directed to the URL in order to register. This should mitigate bot signups.

Down the line I intend to add the ability to generate a unique registration url for each invite, and allow the admin to assign groups and quotas etc prior to signup.