### PR TITLE
Security: Plain text password storage in Registration entity

### DIFF
--- a/lib/Db/Registration.php
+++ b/lib/Db/Registration.php
@@ -39,6 +39,13 @@ class Registration extends Entity {
 	protected $emailConfirmed;
 	protected $clientSecret;
 
+	/**
+	 * Set the password with hashing
+	 */
+	public function setPassword(string $password): void {
+		$this->setValue('password', password_hash($password, PASSWORD_DEFAULT));
+	}
+
 	public function __construct() {
 		$this->addType('email', 'string');
 		$this->addType('username', 'string');


### PR DESCRIPTION
## Summary

Security: Plain text password storage in Registration entity

## Problem

**Severity**: `High` | **File**: `lib/Db/Registration.php:L29`

The Registration entity (lib/Db/Registration.php) stores passwords in plain text. The password field is defined as a string type with no hashing applied before storage. While this is for pending registrations that haven't been created as users yet, storing plain text passwords temporarily in the database is a security concern.

## Solution

Consider hashing passwords before storing them in the registration table, or ensure the password is only stored temporarily and never logged or exposed.

## Changes

- `lib/Db/Registration.php` (modified)