### PR TITLE
Use SPDX license identifier

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -29,7 +29,7 @@ This app allows users to register a new account.
 5. New account is created and is logged in automatically
 		]]></description>
 	<version>3.0.0</version>
-	<licence>agpl</licence>
+	<licence>AGPL-3.0-or-later</licence>
 	<author mail="nextcloud@tcit.fr" homepage="https://tcit.fr">Thomas Citharel</author>
 	<author>Joas Schilling</author>
 	<author mail="pellaeon@cnmc.tw" homepage="https://nyllep.wordpress.com/about-2">Pellaeon Lin</author>

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 	},
 	"name": "nextcloud/registration",
 	"description": "registration",
-	"license": "AGPL",
+	"license": "AGPL-3.0-or-later",
 	"scripts": {
 		"cs:check": "php-cs-fixer fix --dry-run --diff",
 		"cs:fix": "php-cs-fixer fix",


### PR DESCRIPTION
unifying the license string, already used in package.json and supported in info.xml since 31, so no issue given min-version is set to 32 at the moment.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
